### PR TITLE
Send 'IN' command before 'OI' in what_plotter_in_port

### DIFF
--- a/chiplotle/tools/serialtools/what_plotter_in_port.py
+++ b/chiplotle/tools/serialtools/what_plotter_in_port.py
@@ -19,6 +19,7 @@ def what_plotter_in_port(port, wait_time=10):
     try:
         ser.flushInput()
         ser.flushOutput()
+        ser.write('IN;')
         ser.write('OI;')
     except serial.serialutil.SerialException:
         return None


### PR DESCRIPTION
This was necessary to get my HP 7475A plotter to be detected – it wouldn't reply to an `OI;` unless it first received `IN;`. Not sure how this would affect other plotter models.