### PR TITLE
Importing LB, BL, DT commands patch

### DIFF
--- a/chiplotle/tools/hpgltools/inflate_hpgl_string.py
+++ b/chiplotle/tools/hpgltools/inflate_hpgl_string.py
@@ -74,13 +74,13 @@ def _parse_hpgl_command_string(cmd_string):
         coords = re.split('[, ]', cmd_string[2:].strip())
         if coords == ['']:
             coords = []
-        coords = [eval(n) for n in coords]
+        coords = [eval(n) for n in coords if n != '']  # whitespace as separator
         coords = flat_list_to_pairs(coords)
         body = '(%s)' % coords
     elif head in ('RA','RR','ER','EA',):
         body = '(%s)' % cmd_string[2:]
     elif head in ('AR', 'AA'):
-        parameters = re.split('[, ]', cmd_string[2:])
+        parameters = re.split('[, ]', cmd_string[2:].strip())
         x = parameters.pop(0)
         y = parameters.pop(0)
         body = '(%s,%s),%s' % (x, y, ','.join(parameters))

--- a/chiplotle/tools/hpgltools/inflate_hpgl_string.py
+++ b/chiplotle/tools/hpgltools/inflate_hpgl_string.py
@@ -2,6 +2,7 @@ from chiplotle.hpgl import commands as hpgl
 from chiplotle.tools.hpgltools.parse_hpgl_string import parse_hpgl_string
 from chiplotle.tools.logtools.apply_logger import apply_logger
 from chiplotle.tools.iterabletools.flat_list_to_pairs import flat_list_to_pairs
+import re
 
 def inflate_hpgl_string(string, filter_commands=None):
     '''Reads a text string and "inflates" it by creating
@@ -50,8 +51,12 @@ def inflate_hpgl_string_command(cmd_string):
     '''
     head, body = _parse_hpgl_command_string(cmd_string)
     try:
-        result = eval('hpgl.%s(%s)' % (head, body))
-        return result
+        if head in ("DT", "LB", "BL"):
+            result = eval('hpgl.%s("%s")' % (head, body))
+            return result
+        else:
+            result = eval('hpgl.%s(%s)' % (head, body))
+            return result
     except:
         msg = 'Could not create %s(%s)...' % (head, body)
         msg += ' The command is either malformed or unrecognized.'
@@ -64,7 +69,9 @@ def _parse_hpgl_command_string(cmd_string):
     '''
     head = cmd_string[0:2]
     if head in ('PU','PD','PA','PR','IP','IW','SC'):
-        coords = cmd_string[2:].split(',')
+        # NOTE: some files have whitespace as separator,
+        # even though that's not the official grammar
+        coords = re.split('[, ]', cmd_string[2:].strip())
         if coords == ['']:
             coords = []
         coords = [eval(n) for n in coords]
@@ -73,10 +80,12 @@ def _parse_hpgl_command_string(cmd_string):
     elif head in ('RA','RR','ER','EA',):
         body = '(%s)' % cmd_string[2:]
     elif head in ('AR', 'AA'):
-        parameters = cmd_string[2:].split(',')
+        parameters = re.split('[, ]', cmd_string[2:])
         x = parameters.pop(0)
         y = parameters.pop(0)
         body = '(%s,%s),%s' % (x, y, ','.join(parameters))
+    elif head in ('LB', 'BL'):
+        body = cmd_string[2:-1]  # skip the terminator
     else:
         body = cmd_string[2:]
     return head, body

--- a/chiplotle/tools/hpgltools/parse_hpgl_string.py
+++ b/chiplotle/tools/hpgltools/parse_hpgl_string.py
@@ -1,5 +1,6 @@
 import re
 
+
 def parse_hpgl_string(arg):
     '''The function takes a string `arg` of HPGL commands, parses them
     (separates them) and returns them in a list.
@@ -7,28 +8,34 @@ def parse_hpgl_string(arg):
     if not isinstance(arg, str):
         raise TypeError('`arg` must be of type string.')
 
-    string_commands    = ['LB', 'DT']
-    numeric_commands  = ['AA','AF','AH','AP','AR','AS',
-        'BF','BL',
-        'CA','CC','CI','CM','CP','CS','CT','CV',
-        'DC','DF','DI','DP','DR','DS','DV', #DL
-        'EA','EC','EP','ER','ES','EW',
-        'FP','FR','FS','FT',
-        'GC', #GM GP
-        'IM','IN','IP','IV','IW',
-        'KY',
-        'LO','LT',
-        'NR',
-        'OA','OC','OD','OE','OF','OG','OH','OI','OK','OL','OO','OP','OS','OT','OW',
-        'PA','PB','PD','PG','PM','PR','PS','PT','PU',
-        'RA','RO','RR',
-        'SA','SC','SI','SL','SM','SP','SR','SS', #SG
-        'TL',
-        #'UC', UF
-        'VS',
-        'WD','WG',
-        'XT',
-        'YT']
+    # find label terminator first (DT)
+    try:
+        terminator = re.search('DT(.*?)(,[01])?;', arg).group(1)
+    except:
+        terminator = '\x03'  # EOT
+
+    string_commands = ['LB', 'BL']
+    numeric_commands = ['AA', 'AF', 'AH', 'AP', 'AR', 'AS',
+                        'BF',
+                        'CA', 'CC', 'CI', 'CM', 'CP', 'CS', 'CT', 'CV',
+                        'DC', 'DF', 'DI', 'DP', 'DR', 'DS', 'DV',  # DL
+                        'EA', 'EC', 'EP', 'ER', 'ES', 'EW',
+                        'FP', 'FR', 'FS', 'FT',
+                        'GC',  # GM GP
+                        'IM', 'IN', 'IP', 'IV', 'IW',
+                        'KY',
+                        'LO', 'LT',
+                        'NR',
+                        'OA', 'OC', 'OD', 'OE', 'OF', 'OG', 'OH', 'OI', 'OK', 'OL', 'OO', 'OP', 'OS', 'OT', 'OW',
+                        'PA', 'PB', 'PD', 'PG', 'PM', 'PR', 'PS', 'PT', 'PU',
+                        'RA', 'RO', 'RR',
+                        'SA', 'SC', 'SI', 'SL', 'SM', 'SP', 'SR', 'SS',  # SG
+                        'TL',
+                        # 'UC', UF
+                        'VS',
+                        'WD', 'WG',
+                        'XT',
+                        'YT']
     ## TODO: Add all the supported escape (DCI) commands.
     dci_commands = ['\x1b\.\(', '\x1b\.Y']
 
@@ -36,14 +43,14 @@ def parse_hpgl_string(arg):
     # 'PA1.99,-5.00;' -- the ,- construction wasn't being parsed correctly.
     # Don't understand why normal negative integers were being parsed
     # correctly though...
-    # TODO: the whole parser needs to be rewritten. This is simple,
-    #         but inaccurate, especially for DT/LB commands.
-    numeric_pattern= '|'.join([c + '[-0-9.,]*' for c in numeric_commands])
-    dci_pattern     = '|'.join([c + '[0-9.;]*' for c in dci_commands])
-    string_pattern = '|'.join([c + '[^;]+' for c in string_commands])
+    # NOTE: some files have whitespace as separator,
+    # even though that's not the official grammar
+    numeric_pattern = '|'.join([c + '[-0-9., ]*' for c in numeric_commands])
+    dci_pattern = '|'.join([c + '[0-9.;]*' for c in dci_commands])
+    string_pattern = '|'.join([c + '.*?[%s]' % terminator for c in string_commands])
     pattern = '|'.join([numeric_pattern, string_pattern, dci_pattern])
     ## this assumes that the re will find each and every hpgl command
     ## with the pattern. Any command not matched will effectively be
     ## removed... we don't want that.
     result = re.findall(pattern, arg)
-    return result
+    return ['DT' + terminator] + result

--- a/chiplotle/tools/hpgltools/parse_hpgl_string.py
+++ b/chiplotle/tools/hpgltools/parse_hpgl_string.py
@@ -11,6 +11,8 @@ def parse_hpgl_string(arg):
     # find label terminator first (DT)
     try:
         terminator = re.search('DT(.*?)(,[01])?;', arg).group(1)
+        if len(terminator) == 0:
+            terminator = '\x03'  # EOT
     except:
         terminator = '\x03'  # EOT
 

--- a/chiplotle/tools/io/import_hpgl_file.py
+++ b/chiplotle/tools/io/import_hpgl_file.py
@@ -19,4 +19,4 @@ def import_hpgl_file(filename, filter_commands=None):
     fs = f.read()
     f.close()
 
-    return inflate_hpgl_string(fs, filter_commands)
+    return inflate_hpgl_string(fs.replace("\n", ""), filter_commands)


### PR DESCRIPTION
The parsing of LB, BL, DT now works fine according to [HPGL grammar](https://www.isoplotec.co.jp/HPGL/eHPGL.htm) and HPGL files I've received from my client. The files come from designing software, [NX](https://www.plm.automation.siemens.com/global/en/products/nx/) and [Nadams](https://jglobal.jst.go.jp/detail?JGLOBAL_ID=200902081782271069). Note that I don't own any printer to test, this is only importing + parsing.